### PR TITLE
+ Added session destroy on bind error. Calling destroy will clean up …

### DIFF
--- a/src/main/java/com/cloudhopper/smpp/impl/DefaultSmppClient.java
+++ b/src/main/java/com/cloudhopper/smpp/impl/DefaultSmppClient.java
@@ -204,7 +204,7 @@ public class DefaultSmppClient implements SmppClient {
                 // make sure that the resources are always cleaned up
                 try { 
                     logger.debug("Closing session - not able to bind to " + config.getName());
-                    session.close(); 
+                    session.destroy();
                 } 
                 catch (Exception e) {
                     logger.debug("Exception while trying to close connection to " + config.getName(), e);


### PR DESCRIPTION
…resources such as WindowMonitor for proper session close and clean up.

Issue: https://github.com/RestComm/cloudhopper-smpp/issues/9

@see also
https://github.com/twitter/cloudhopper-smpp/issues/45
https://github.com/twitter/cloudhopper-smpp/commit/ba14f94e7d2f84cad198e6bafaa6a15ac6fdfce4