### PR TITLE
Fixed bind response not sending if sessionCreated failed

### DIFF
--- a/src/main/java/com/cloudhopper/smpp/SmppServerHandler.java
+++ b/src/main/java/com/cloudhopper/smpp/SmppServerHandler.java
@@ -22,6 +22,7 @@ package com.cloudhopper.smpp;
 
 import com.cloudhopper.smpp.pdu.BaseBind;
 import com.cloudhopper.smpp.pdu.BaseBindResp;
+import com.cloudhopper.smpp.type.SessionCreatedFailedException;
 import com.cloudhopper.smpp.type.SmppProcessingException;
 
 /**
@@ -79,8 +80,11 @@ public interface SmppServerHandler {
      *      rejected.  If thrown, a bind response with the SMPP status code
      *      contained in this exception will be generated and returned back to
      *      the client.
+     * @throws SessionCreatedFailedException Thrown if a problem occurred
+     *      while after-creation actions processing and before OK response
+     *      sending to the binding client.
      */
-    public void sessionCreated(Long sessionId, SmppServerSession session, BaseBindResp preparedBindResponse) throws SmppProcessingException;
+    public void sessionCreated(Long sessionId, SmppServerSession session, BaseBindResp preparedBindResponse) throws SmppProcessingException, SessionCreatedFailedException;
 
     /**
      * Triggered when a session is unbound and closed with the client.

--- a/src/main/java/com/cloudhopper/smpp/SmppServerSession.java
+++ b/src/main/java/com/cloudhopper/smpp/SmppServerSession.java
@@ -43,4 +43,11 @@ public interface SmppServerSession extends SmppSession {
      */
     public void serverReady(SmppSessionHandler sessionHandler);
 
+    /**
+     * Indicates that the local endpoint (server) is not ready to start
+     * processing requests for the session. Aborts the bind process
+     * by the remote endpoint by sending back the failed bind response.
+     */
+    public void serverNotReady();
+
 }

--- a/src/main/java/com/cloudhopper/smpp/impl/DefaultSmppServer.java
+++ b/src/main/java/com/cloudhopper/smpp/impl/DefaultSmppServer.java
@@ -365,8 +365,8 @@ public class DefaultSmppServer implements SmppServer, DefaultSmppServerMXBean {
         try {
             this.serverHandler.sessionCreated(sessionId, session, preparedBindResponse);
         } catch (SessionCreatedFailedException e) {
-            logger.error("sessionCreated call on serverHandler failed. Unable to finish the binding. " +
-                    "Session is going to be destroyed.", e);
+            logger.error("sessionCreated call on {} failed. Unable to finish the binding. " +
+                    "Session is going to be destroyed.", serverHandler.getClass().getName(), e);
             session.serverNotReady();
             destroySession(sessionId, session);
             throw e;

--- a/src/main/java/com/cloudhopper/smpp/impl/DefaultSmppServer.java
+++ b/src/main/java/com/cloudhopper/smpp/impl/DefaultSmppServer.java
@@ -38,6 +38,7 @@ import com.cloudhopper.smpp.tlv.Tlv;
 import com.cloudhopper.smpp.transcoder.DefaultPduTranscoder;
 import com.cloudhopper.smpp.transcoder.DefaultPduTranscoderContext;
 import com.cloudhopper.smpp.transcoder.PduTranscoder;
+import com.cloudhopper.smpp.type.SessionCreatedFailedException;
 import com.cloudhopper.smpp.type.SmppChannelException;
 import com.cloudhopper.smpp.type.SmppProcessingException;
 import com.cloudhopper.smpp.util.DaemonExecutors;
@@ -314,7 +315,7 @@ public class DefaultSmppServer implements SmppServer, DefaultSmppServerMXBean {
     }
 
 
-    protected void createSession(Long sessionId, Channel channel, SmppSessionConfiguration config, BaseBindResp preparedBindResponse) throws SmppProcessingException {
+    protected void createSession(Long sessionId, Channel channel, SmppSessionConfiguration config, BaseBindResp preparedBindResponse, BaseBindResp failedBindResponse) throws SmppProcessingException, SessionCreatedFailedException {
         // NOTE: exactly one PDU (bind request) was read from the channel, we
         // now need to delegate permitting this bind request by calling a method
         // further upstream.  Only after the server-side is completely ready to
@@ -330,7 +331,7 @@ public class DefaultSmppServer implements SmppServer, DefaultSmppServerMXBean {
         byte interfaceVersion = this.autoNegotiateInterfaceVersion(config.getInterfaceVersion());
 
         // create a new server session associated with this server
-        DefaultSmppSession session = new DefaultSmppSession(SmppSession.Type.SERVER, config, channel, this, sessionId, preparedBindResponse, interfaceVersion, monitorExecutor);
+        DefaultSmppSession session = new DefaultSmppSession(SmppSession.Type.SERVER, config, channel, this, sessionId, preparedBindResponse, failedBindResponse, interfaceVersion, monitorExecutor);
 
         // replace name of thread used for renaming
         SmppSessionThreadRenamer threadRenamer = (SmppSessionThreadRenamer)channel.getPipeline().get(SmppChannelConstants.PIPELINE_SESSION_THREAD_RENAMER_NAME);
@@ -360,8 +361,17 @@ public class DefaultSmppServer implements SmppServer, DefaultSmppServerMXBean {
         // session created, now pass it upstream
         counters.incrementSessionCreatedAndGet();
         incrementSessionSizeCounters(session);
-        this.serverHandler.sessionCreated(sessionId, session, preparedBindResponse);
-        
+
+        try {
+            this.serverHandler.sessionCreated(sessionId, session, preparedBindResponse);
+        } catch (SessionCreatedFailedException e) {
+            logger.error("sessionCreated call on serverHandler failed. Unable to finish the binding. " +
+                    "Session is going to be destroyed.", e);
+            session.serverNotReady();
+            destroySession(sessionId, session);
+            throw e;
+        }
+
         // register this session as an mbean
         if (configuration.isJmxEnabled()) {
             session.registerMBean(configuration.getJmxDomain() + ":type=" + configuration.getName() + "Sessions,name=" + sessionId);

--- a/src/main/java/com/cloudhopper/smpp/type/SessionCreatedFailedException.java
+++ b/src/main/java/com/cloudhopper/smpp/type/SessionCreatedFailedException.java
@@ -1,0 +1,18 @@
+package com.cloudhopper.smpp.type;
+
+import com.cloudhopper.smpp.SmppServerHandler;
+
+/**
+ * Thrown only in {@link SmppServerHandler#sessionCreated}.
+ * Indicates the problem that prevents the binding process from finishing.
+ * Must be used only for the cases when the problem occurred
+ * <b>before</b> OK response sending to the client.
+ * <BR>
+ * Thus the right way to handle the exception is
+ * to destroy the session and release resources.
+ */
+public class SessionCreatedFailedException extends Exception {
+    public SessionCreatedFailedException(Throwable cause) {
+        super(cause);
+    }
+}


### PR DESCRIPTION
Any exception throwed in an implementation of `com.cloudhopper.smpp.SmppServerHandler#sessionCreated` leads to not sending bind_resp to the client. But in fact session is created on the server (and not gonna be destroyed), but it won't be used by the client. Instead the client won't receive any answer and concludes that something went wrong and it needs to rebind (while the server is sure that connection is already established). This can result in the client being unable to reconnect at all.

In general ch_smpp library is not ready to get any unexpected exception while after-session-created actions processing.

This PR adds `SessionCreatedFailedException.java` that can be used to wrap any exception in `#sessioCreated`. The way of the exception handling by the library is as follows:

1. explicitly log the error
2. answer with `Bind failed` response to the client
3. destroy the session
4. close the channel (explicitly)

Example of usage in `#sessionCreated` implementation: `#handleConnectionEstablished` may produce an exception in case of a wrong intermnal config. Thus it's in a try-block with a catch rethrowing the exception wrapped in `SessionCreatedFailedException`

```kotlin
try {
    connectionTaskManager.handleConnectionEstablished(
            sessionId,
            authDetails,
            session,
            asyncPduSender,
            (ConnectionListener) pduSniffer
    );
} catch (Exception e) {
    throw new SessionCreatedFailedException(e);
}
```